### PR TITLE
Add Ollama CLI support as AI provider option

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,7 @@
 │   │                           #   POST /api/ideas/{id}/run       → call_ai() → tasks 생성
 │   │                           #   call_ai(): ai_provider에 따라 OpenAI/Anthropic API/Gemini API/Claude CLI/Gemini CLI/Ollama CLI 분기
 │   ├── data.json               # 데이터 영속 파일 (workspaces 배열)
-│   └── settings.config         # 앱 설정 (JSON): theme, ai_provider, api_keys{openai,anthropic,gemini}, ollama_model
+│   └── settings.config         # 앱 설정 (JSON): language, theme, ai_provider, api_keys{openai,anthropic,gemini}, ollama_model
 ├── ARCHITECTURE.md             # (이 파일) 프로젝트 구조 나침반 — AI 전용
 ├── CLAUDE.md                   # Claude Code 행동 규칙 및 제약 조건
 ├── README.md                   # 프로젝트 소개

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,9 +32,9 @@
 │   │                           #   POST /api/install-python       → install_python 스크립트 실행
 │   │                           #   POST /api/install-package      → pip install (provider별 패키지)
 │   │                           #   POST /api/ideas/{id}/run       → call_ai() → tasks 생성
-│   │                           #   call_ai(): ai_provider에 따라 OpenAI/Anthropic API/Gemini API/Claude CLI/Gemini CLI 분기
+│   │                           #   call_ai(): ai_provider에 따라 OpenAI/Anthropic API/Gemini API/Claude CLI/Gemini CLI/Ollama CLI 분기
 │   ├── data.json               # 데이터 영속 파일 (workspaces 배열)
-│   └── settings.config         # 앱 설정 (JSON): theme, ai_provider, api_keys{openai,anthropic,gemini}
+│   └── settings.config         # 앱 설정 (JSON): theme, ai_provider, api_keys{openai,anthropic,gemini}, ollama_model
 ├── ARCHITECTURE.md             # (이 파일) 프로젝트 구조 나침반 — AI 전용
 ├── CLAUDE.md                   # Claude Code 행동 규칙 및 제약 조건
 ├── README.md                   # 프로젝트 소개

--- a/apps/onboarding.html
+++ b/apps/onboarding.html
@@ -525,6 +525,10 @@
             <div class="pname">Gemini CLI</div>
             <div class="ptype" id="ptype-gc">CLI 설치 필요</div>
           </button>
+          <button class="provider-btn" data-provider="ollama_cli" onclick="selectProvider('ollama_cli')">
+            <div class="pname">Ollama CLI</div>
+            <div class="ptype" id="ptype-oc">로컬 CLI 실행</div>
+          </button>
         </div>
 
         <!-- API 타입 UI -->
@@ -542,6 +546,10 @@
         <!-- CLI 타입 UI -->
         <div id="cli-setup" style="display:none;">
           <div class="msg-box info visible" id="cli-msg">CLI가 설치되어 있다면 바로 다음으로 진행하세요.</div>
+          <div id="ollama-model-setup" style="display:none; margin-top:10px;">
+            <label class="api-key-label" style="display:block; margin-bottom:4px;">Ollama 모델 이름</label>
+            <input type="text" class="api-key-input" id="ollama-model-input" placeholder="llama3.2">
+          </div>
         </div>
 
         <div class="btn-row" style="margin-top:14px;">
@@ -916,6 +924,7 @@ function selectProvider(provider) {
     document.getElementById('api-key-input').placeholder = KEY_PLACEHOLDER[provider] || 'API Key';
     document.getElementById('step2-save').disabled = true;
   } else {
+    document.getElementById('ollama-model-setup').style.display = provider === 'ollama_cli' ? 'block' : 'none';
     document.getElementById('step2-save').disabled = false;
   }
 }
@@ -972,6 +981,9 @@ async function saveAI() {
   if (isApi) {
     const keyMap = { claude_api: 'anthropic', openai: 'openai', gemini: 'gemini' };
     payload.api_keys = { [keyMap[selectedProvider]]: key };
+  }
+  if (selectedProvider === 'ollama_cli') {
+    payload.ollama_model = document.getElementById('ollama-model-input').value.trim() || 'llama3.2';
   }
 
   try {

--- a/apps/onboarding.html
+++ b/apps/onboarding.html
@@ -983,7 +983,8 @@ async function saveAI() {
     payload.api_keys = { [keyMap[selectedProvider]]: key };
   }
   if (selectedProvider === 'ollama_cli') {
-    payload.ollama_model = document.getElementById('ollama-model-input').value.trim() || 'llama3.2';
+    const ollamaModel = document.getElementById('ollama-model-input').value.trim();
+    if (ollamaModel) payload.ollama_model = ollamaModel;
   }
 
   try {

--- a/apps/server.py
+++ b/apps/server.py
@@ -38,7 +38,9 @@ def read_settings():
     if not SETTINGS_FILE.exists():
         return {'theme': 'light', 'ai_provider': 'claude_cli', 'api_keys': {'openai': '', 'anthropic': '', 'gemini': ''}, 'ollama_model': 'llama3.2'}
     with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
-        return json.load(f)
+        data = json.load(f)
+    data.setdefault('ollama_model', 'llama3.2')
+    return data
 
 
 def write_settings(settings):

--- a/apps/server.py
+++ b/apps/server.py
@@ -36,9 +36,10 @@ def write_data(data):
 
 def read_settings():
     if not SETTINGS_FILE.exists():
-        return {'theme': 'light', 'ai_provider': 'claude_cli', 'api_keys': {'openai': '', 'anthropic': '', 'gemini': ''}, 'ollama_model': 'llama3.2'}
+        return {'language': 'ko', 'theme': 'light', 'ai_provider': 'claude_cli', 'api_keys': {'openai': '', 'anthropic': '', 'gemini': ''}, 'ollama_model': 'llama3.2'}
     with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
         data = json.load(f)
+    data.setdefault('language', 'ko')
     data.setdefault('ollama_model', 'llama3.2')
     return data
 

--- a/apps/server.py
+++ b/apps/server.py
@@ -36,7 +36,7 @@ def write_data(data):
 
 def read_settings():
     if not SETTINGS_FILE.exists():
-        return {'theme': 'light', 'ai_provider': 'claude_cli', 'api_keys': {'openai': '', 'anthropic': '', 'gemini': ''}}
+        return {'theme': 'light', 'ai_provider': 'claude_cli', 'api_keys': {'openai': '', 'anthropic': '', 'gemini': ''}, 'ollama_model': 'llama3.2'}
     with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
         return json.load(f)
 
@@ -106,7 +106,7 @@ def call_ai(prompt, timeout=120):
         return result.stdout.strip()
 
     elif provider == 'ollama_cli':
-        ollama_model = settings.get('ollama_model', 'llama3.2')
+        ollama_model = settings.get('ollama_model', '').strip() or 'llama3.2'
         result = subprocess.run(
             ['ollama', 'run', ollama_model],
             input=prompt,

--- a/apps/server.py
+++ b/apps/server.py
@@ -105,6 +105,17 @@ def call_ai(prompt, timeout=120):
             raise RuntimeError(result.stderr.strip() or 'Gemini CLI 오류')
         return result.stdout.strip()
 
+    elif provider == 'ollama_cli':
+        ollama_model = settings.get('ollama_model', 'llama3.2')
+        result = subprocess.run(
+            ['ollama', 'run', ollama_model],
+            input=prompt,
+            capture_output=True, text=True, timeout=timeout
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or 'Ollama CLI 오류')
+        return result.stdout.strip()
+
     else:  # claude_cli (default)
         result = subprocess.run(
             [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
@@ -209,6 +220,8 @@ class Handler(SimpleHTTPRequestHandler):
             self._handle_claude_check()
         elif self.path == '/api/gemini-check':
             self._handle_gemini_check()
+        elif self.path == '/api/ollama-check':
+            self._handle_ollama_check()
         elif self.path == '/api/browse-folder':
             self._handle_browse_folder()
         else:
@@ -274,7 +287,7 @@ class Handler(SimpleHTTPRequestHandler):
         settings = read_settings()
         provider = settings.get('ai_provider', '')
         keys = settings.get('api_keys', {})
-        if provider in ('claude_cli', 'gemini_cli'):
+        if provider in ('claude_cli', 'gemini_cli', 'ollama_cli'):
             ai_connected = True
         elif provider == 'claude_api' and keys.get('anthropic', '').strip():
             ai_connected = True
@@ -389,6 +402,24 @@ class Handler(SimpleHTTPRequestHandler):
                 self._send_json(200, {'ok': False, 'error': result.stderr.strip()})
         except FileNotFoundError:
             self._send_json(200, {'ok': False, 'error': 'Gemini CLI를 찾을 수 없습니다'})
+        except subprocess.TimeoutExpired:
+            self._send_json(200, {'ok': False, 'error': '응답 시간 초과'})
+        except Exception as e:
+            self._send_json(200, {'ok': False, 'error': str(e)})
+
+    def _handle_ollama_check(self):
+        try:
+            result = subprocess.run(
+                ['ollama', '--version'],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                version = result.stdout.strip() or result.stderr.strip()
+                self._send_json(200, {'ok': True, 'version': version})
+            else:
+                self._send_json(200, {'ok': False, 'error': result.stderr.strip()})
+        except FileNotFoundError:
+            self._send_json(200, {'ok': False, 'error': 'Ollama CLI를 찾을 수 없습니다'})
         except subprocess.TimeoutExpired:
             self._send_json(200, {'ok': False, 'error': '응답 시간 초과'})
         except Exception as e:

--- a/apps/settings.html
+++ b/apps/settings.html
@@ -382,6 +382,7 @@
         <button class="btn-provider" data-provider="openai">GPT-4o</button>
         <button class="btn-provider" data-provider="gemini">Gemini API</button>
         <button class="btn-provider" data-provider="gemini_cli">Gemini CLI</button>
+        <button class="btn-provider" data-provider="ollama_cli">Ollama CLI</button>
       </div>
       <div id="api-key-row" style="display:none; width:100%; max-width:400px; flex-direction:column; gap:6px;">
         <label id="api-key-label" style="font-size:calc(12px * var(--fs,1)); color:#888; text-align:center;"></label>
@@ -390,6 +391,10 @@
           <span class="pkg-status-badge" id="pkg-status-badge">미확인</span>
         </div>
         <input type="password" id="api-key-input" class="api-key-input" placeholder="API 키를 입력하세요">
+      </div>
+      <div id="ollama-model-row" style="display:none; width:100%; max-width:400px; flex-direction:column; gap:6px;">
+        <label style="font-size:calc(12px * var(--fs,1)); color:#888; text-align:center;">Ollama 모델 이름</label>
+        <input type="text" id="ollama-model-input" class="api-key-input" placeholder="llama3.2">
       </div>
       <div style="width:100%; max-width:400px; display:flex; flex-direction:column; align-items:center; gap:6px;">
         <button class="btn-action" id="btn-save-provider" onclick="saveProvider()" style="width:100%; padding:8px 0;">저장</button>
@@ -415,6 +420,16 @@
         <span class="status-badge idle" id="gemini-status">미확인</span>
       </div>
       <div id="gemini-version" style="font-size:calc(12px * var(--fs, 1)); color:#888; text-align:center;"></div>
+    </div>
+
+    <div class="settings-section" id="ollama-cli-check" style="display:none;">
+      <h2>Ollama CLI 연결 확인</h2>
+      <div class="settings-row">
+        <span class="settings-label">연결 상태</span>
+        <button class="btn-action" id="btn-check-ollama" onclick="checkOllama()">연결 확인</button>
+        <span class="status-badge idle" id="ollama-status">미확인</span>
+      </div>
+      <div id="ollama-version" style="font-size:calc(12px * var(--fs, 1)); color:#888; text-align:center;"></div>
     </div>
 
     <div class="settings-section">
@@ -582,16 +597,47 @@
       }
     }
 
+    async function checkOllama() {
+      const btn = document.getElementById('btn-check-ollama');
+      const badge = document.getElementById('ollama-status');
+      const versionEl = document.getElementById('ollama-version');
+
+      btn.disabled = true;
+      badge.className = 'status-badge idle';
+      badge.textContent = '확인 중…';
+      versionEl.textContent = '';
+
+      try {
+        const res = await fetch('/api/ollama-check');
+        const data = await res.json();
+        if (data.ok) {
+          badge.className = 'status-badge ok';
+          badge.textContent = '연결됨';
+          versionEl.textContent = data.version;
+        } else {
+          badge.className = 'status-badge fail';
+          badge.textContent = '연결 실패';
+          versionEl.textContent = data.error;
+        }
+      } catch {
+        badge.className = 'status-badge fail';
+        badge.textContent = '서버 오류';
+      } finally {
+        btn.disabled = false;
+      }
+    }
+
     // ── AI 프로바이더 ──────────────────────────────────────
     const PROVIDER_LABELS = {
       claude_cli: null,
       claude_api: 'Anthropic API 키 (sk-ant-...)',
       openai: 'OpenAI API 키 (sk-...)',
       gemini: 'Google Gemini API 키',
-      gemini_cli: null
+      gemini_cli: null,
+      ollama_cli: null
     };
 
-    let _currentSettings = { ai_provider: 'claude_cli', api_keys: { openai: '', anthropic: '', gemini: '' } };
+    let _currentSettings = { ai_provider: 'claude_cli', api_keys: { openai: '', anthropic: '', gemini: '' }, ollama_model: '' };
     let _selectedProvider = 'claude_cli';
 
     function _providerToKeyName(provider) {
@@ -623,8 +669,16 @@
         keyRow.style.display = 'none';
         input.value = '';
       }
+      const ollamaRow = document.getElementById('ollama-model-row');
+      if (provider === 'ollama_cli') {
+        ollamaRow.style.display = 'flex';
+        document.getElementById('ollama-model-input').value = _currentSettings.ollama_model || '';
+      } else {
+        ollamaRow.style.display = 'none';
+      }
       document.getElementById('claude-cli-check').style.display = provider === 'claude_cli' ? '' : 'none';
       document.getElementById('gemini-cli-check').style.display = provider === 'gemini_cli' ? '' : 'none';
+      document.getElementById('ollama-cli-check').style.display = provider === 'ollama_cli' ? '' : 'none';
       document.getElementById('provider-save-msg').textContent = '';
     }
 
@@ -632,7 +686,7 @@
       try {
         const res = await fetch('/api/settings');
         const data = await res.json();
-        _currentSettings = data;
+        _currentSettings = { ...data, ollama_model: data.ollama_model || '' };
         _updateProviderUI(data.ai_provider || 'claude_cli');
       } catch {
         // 서버 미연결 상태에서도 UI는 초기값으로 표시
@@ -684,16 +738,22 @@
         updatedKeys[keyName] = document.getElementById('api-key-input').value.trim();
       }
 
+      const payload = { ai_provider: _selectedProvider, api_keys: updatedKeys };
+      if (_selectedProvider === 'ollama_cli') {
+        payload.ollama_model = document.getElementById('ollama-model-input').value.trim() || 'llama3.2';
+      }
+
       try {
         const res = await fetch('/api/settings', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ai_provider: _selectedProvider, api_keys: updatedKeys })
+          body: JSON.stringify(payload)
         });
         const data = await res.json();
         if (data.ok) {
           _currentSettings.ai_provider = _selectedProvider;
           _currentSettings.api_keys = updatedKeys;
+          if (_selectedProvider === 'ollama_cli') _currentSettings.ollama_model = payload.ollama_model;
           msg.textContent = '저장됨';
           setTimeout(() => { msg.textContent = ''; }, 2000);
         } else {

--- a/apps/settings.html
+++ b/apps/settings.html
@@ -740,7 +740,8 @@
 
       const payload = { ai_provider: _selectedProvider, api_keys: updatedKeys };
       if (_selectedProvider === 'ollama_cli') {
-        payload.ollama_model = document.getElementById('ollama-model-input').value.trim() || 'llama3.2';
+        const ollamaModel = document.getElementById('ollama-model-input').value.trim();
+        if (ollamaModel) payload.ollama_model = ollamaModel;
       }
 
       try {

--- a/apps/settings.html
+++ b/apps/settings.html
@@ -754,7 +754,9 @@
         if (data.ok) {
           _currentSettings.ai_provider = _selectedProvider;
           _currentSettings.api_keys = updatedKeys;
-          if (_selectedProvider === 'ollama_cli') _currentSettings.ollama_model = payload.ollama_model;
+          if (_selectedProvider === 'ollama_cli' && Object.prototype.hasOwnProperty.call(payload, 'ollama_model')) {
+            _currentSettings.ollama_model = payload.ollama_model;
+          }
           msg.textContent = '저장됨';
           setTimeout(() => { msg.textContent = ''; }, 2000);
         } else {


### PR DESCRIPTION
## Summary
This PR adds support for Ollama CLI as a new AI provider option, allowing users to run local language models via Ollama alongside existing providers (Claude, OpenAI, Gemini).

## Key Changes

### Frontend (Settings & Onboarding)
- Added "Ollama CLI" button to AI provider selection in settings and onboarding
- Added model name input field that appears when Ollama CLI is selected (defaults to "llama3.2")
- Added connection check section for Ollama CLI with status badge and version display
- Updated provider UI logic to show/hide Ollama-specific fields based on selection

### Backend (Server)
- Implemented `call_ai()` support for Ollama CLI provider using `ollama run <model>` subprocess
- Added `/api/ollama-check` endpoint to verify Ollama CLI installation and retrieve version
- Updated system status check to recognize Ollama CLI as a valid local provider
- Modified settings schema to include `ollama_model` field for storing selected model name

### Configuration
- Extended `settings.config` to persist `ollama_model` setting alongside existing provider configs
- Updated ARCHITECTURE.md to document Ollama CLI in the call_ai() flow

## Implementation Details
- Ollama model selection defaults to "llama3.2" if not specified
- Connection check uses `ollama --version` command to verify installation
- Model name is configurable per user preference
- Ollama CLI is treated as a local provider (no API key required, similar to Claude CLI and Gemini CLI)
- Settings are properly persisted and restored across app sessions

https://claude.ai/code/session_018kDwYx36EKsM7KZQMNSgVF