### PR TITLE
Add explicit encoding and error handling to subprocess calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 2. **파일 접근은 최대 2개로 제한한다.** ARCHITECTURE.md에서 타겟을 특정한 뒤 접근.
 3. **Search/Glob는 ARCHITECTURE.md로 해결 안 될 때만 사용한다.**
 4. **빌드 산출물, lock 파일, .DS_Store는 절대 읽지 않는다.**
-5. **GitHub 이슈 및 PR은 항상 Agent tool을 통해 읽는다.** `mcp__github__` 툴을 직접 호출하지 않는다.
+5. **GitHub 이슈 및 PR은 항상 Agent tool을 통해 읽는다.** Claude가 `mcp__github__` 툴을 직접 호출하는 대신, Agent tool에 위임하여 읽는다.
 
 ## 작업 규칙
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 2. **파일 접근은 최대 2개로 제한한다.** ARCHITECTURE.md에서 타겟을 특정한 뒤 접근.
 3. **Search/Glob는 ARCHITECTURE.md로 해결 안 될 때만 사용한다.**
 4. **빌드 산출물, lock 파일, .DS_Store는 절대 읽지 않는다.**
+5. **GitHub 이슈 및 PR은 항상 Agent tool을 통해 읽는다.** `mcp__github__` 툴을 직접 호출하지 않는다.
 
 ## 작업 규칙
 

--- a/apps/server.py
+++ b/apps/server.py
@@ -414,7 +414,10 @@ class Handler(SimpleHTTPRequestHandler):
 
             if system == 'Windows':
                 # PowerShell FolderBrowserDialog 사용
+                # UTF-8 출력 강제 설정 후 경로 선택
                 ps_script = (
+                    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;"
+                    "$OutputEncoding = [System.Text.Encoding]::UTF8;"
                     "Add-Type -AssemblyName System.Windows.Forms;"
                     "$d = New-Object System.Windows.Forms.FolderBrowserDialog;"
                     "$d.ShowNewFolderButton = $true;"
@@ -717,7 +720,7 @@ class Handler(SimpleHTTPRequestHandler):
                         timeout=5,
                         check=True,
                         capture_output=True,
-                        text=True
+                        text=True, encoding='utf-8', errors='replace'
                     )
                 except FileNotFoundError:
                     self._send_json(500, {'error': "'open' command not found on PATH"})
@@ -733,7 +736,7 @@ class Handler(SimpleHTTPRequestHandler):
                         timeout=5,
                         check=True,
                         capture_output=True,
-                        text=True
+                        text=True, encoding='utf-8', errors='replace'
                     )
                 except FileNotFoundError:
                     self._send_json(500, {'error': "'xdg-open' command not found on PATH"})

--- a/apps/server.py
+++ b/apps/server.py
@@ -18,7 +18,7 @@ BASE_DIR = Path(__file__).parent          # apps/
 DATA_FILE = BASE_DIR / 'data.json'
 SETTINGS_FILE = BASE_DIR / 'settings.config'
 
-# subprocess.run에 text 모드 사용 시 공통 kwargs — 모든 OS에서 UTF-8 인코딩 보장
+# subprocess.run에 text 모드 사용 시 공통 kwargs — UTF-8로 디코딩을 시도하고 실패 시 대체(replace) 처리
 _TEXT_SUBPROCESS = {'text': True, 'encoding': 'utf-8', 'errors': 'replace'}
 
 

--- a/apps/server.py
+++ b/apps/server.py
@@ -135,7 +135,7 @@ def call_ai(prompt, timeout=120):
     elif provider == 'gemini_cli':
         result = subprocess.run(
             ['gemini', '-p', prompt],
-            capture_output=True, text=True, timeout=timeout
+            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Gemini CLI 오류')
@@ -146,7 +146,7 @@ def call_ai(prompt, timeout=120):
         result = subprocess.run(
             ['ollama', 'run', ollama_model],
             input=prompt,
-            capture_output=True, text=True, timeout=timeout
+            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Ollama CLI 오류')
@@ -155,7 +155,7 @@ def call_ai(prompt, timeout=120):
     else:  # claude_cli (default)
         result = subprocess.run(
             [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-            capture_output=True, text=True, timeout=timeout
+            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -358,7 +358,7 @@ class Handler(SimpleHTTPRequestHandler):
             result = subprocess.run(
                 cmd,
                 stdin=subprocess.DEVNULL,
-                capture_output=True, text=True, timeout=300
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=300
             )
             if result.returncode == 0:
                 self._send_json(200, {'success': True, 'message': result.stdout.strip()})
@@ -385,7 +385,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [sys.executable, '-m', 'pip', 'install', pkg],
-                capture_output=True, text=True, timeout=120
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120
             )
             if result.returncode == 0:
                 self._send_json(200, {'success': True, 'message': f'{pkg} 설치 완료'})
@@ -422,7 +422,7 @@ class Handler(SimpleHTTPRequestHandler):
                 )
                 result = subprocess.run(
                     ['powershell', '-NoProfile', '-NonInteractive', '-Command', ps_script],
-                    capture_output=True, text=True, timeout=60
+                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
                 )
                 path = result.stdout.strip()
                 if path:
@@ -436,7 +436,7 @@ class Handler(SimpleHTTPRequestHandler):
                 # 기존 macOS 코드
                 result = subprocess.run(
                     ['osascript', '-e', 'POSIX path of (choose folder)'],
-                    capture_output=True, text=True, timeout=60
+                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
                 )
                 if result.returncode == 0:
                     path = result.stdout.strip()
@@ -448,7 +448,7 @@ class Handler(SimpleHTTPRequestHandler):
                 # Linux — zenity 사용 (설치 필요)
                 result = subprocess.run(
                     ['zenity', '--file-selection', '--directory'],
-                    capture_output=True, text=True, timeout=60
+                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
                 )
                 if result.returncode == 0:
                     self._send_json(200, {'ok': True, 'path': result.stdout.strip()})
@@ -464,7 +464,7 @@ class Handler(SimpleHTTPRequestHandler):
         try:
             result = subprocess.run(
                 ['gemini', '--version'],
-                capture_output=True, text=True, timeout=10
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10
             )
             if result.returncode == 0:
                 version = result.stdout.strip() or result.stderr.strip()
@@ -482,7 +482,7 @@ class Handler(SimpleHTTPRequestHandler):
         try:
             result = subprocess.run(
                 ['ollama', '--version'],
-                capture_output=True, text=True, timeout=10
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10
             )
             if result.returncode == 0:
                 version = result.stdout.strip() or result.stderr.strip()
@@ -500,7 +500,7 @@ class Handler(SimpleHTTPRequestHandler):
         try:
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--version'],
-                capture_output=True, text=True, timeout=10
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10
             )
             if result.returncode == 0:
                 version = result.stdout.strip() or result.stderr.strip()
@@ -615,7 +615,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, text=True, timeout=60
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
             )
 
             if result.returncode != 0:
@@ -660,7 +660,7 @@ class Handler(SimpleHTTPRequestHandler):
             # Claude CLI 실행
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt_text],
-                capture_output=True, text=True, timeout=120
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -777,7 +777,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, text=True, timeout=60
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -809,7 +809,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, text=True, timeout=30
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')

--- a/apps/server.py
+++ b/apps/server.py
@@ -18,6 +18,9 @@ BASE_DIR = Path(__file__).parent          # apps/
 DATA_FILE = BASE_DIR / 'data.json'
 SETTINGS_FILE = BASE_DIR / 'settings.config'
 
+# subprocess.run에 text 모드 사용 시 공통 kwargs — 모든 OS에서 UTF-8 인코딩 보장
+_TEXT_SUBPROCESS = {'text': True, 'encoding': 'utf-8', 'errors': 'replace'}
+
 
 def _find_claude_bin() -> Path:
     """OS에 무관하게 claude CLI 실행 파일 경로를 탐색한다."""
@@ -135,7 +138,7 @@ def call_ai(prompt, timeout=120):
     elif provider == 'gemini_cli':
         result = subprocess.run(
             ['gemini', '-p', prompt],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout
+            capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Gemini CLI 오류')
@@ -146,7 +149,7 @@ def call_ai(prompt, timeout=120):
         result = subprocess.run(
             ['ollama', 'run', ollama_model],
             input=prompt,
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout
+            capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Ollama CLI 오류')
@@ -155,7 +158,7 @@ def call_ai(prompt, timeout=120):
     else:  # claude_cli (default)
         result = subprocess.run(
             [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout
+            capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -358,7 +361,7 @@ class Handler(SimpleHTTPRequestHandler):
             result = subprocess.run(
                 cmd,
                 stdin=subprocess.DEVNULL,
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=300
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=300
             )
             if result.returncode == 0:
                 self._send_json(200, {'success': True, 'message': result.stdout.strip()})
@@ -385,7 +388,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [sys.executable, '-m', 'pip', 'install', pkg],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=120
             )
             if result.returncode == 0:
                 self._send_json(200, {'success': True, 'message': f'{pkg} 설치 완료'})
@@ -425,7 +428,7 @@ class Handler(SimpleHTTPRequestHandler):
                 )
                 result = subprocess.run(
                     ['powershell', '-NoProfile', '-NonInteractive', '-Command', ps_script],
-                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
+                    capture_output=True, **_TEXT_SUBPROCESS, timeout=60
                 )
                 path = result.stdout.strip()
                 if path:
@@ -439,7 +442,7 @@ class Handler(SimpleHTTPRequestHandler):
                 # 기존 macOS 코드
                 result = subprocess.run(
                     ['osascript', '-e', 'POSIX path of (choose folder)'],
-                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
+                    capture_output=True, **_TEXT_SUBPROCESS, timeout=60
                 )
                 if result.returncode == 0:
                     path = result.stdout.strip()
@@ -451,7 +454,7 @@ class Handler(SimpleHTTPRequestHandler):
                 # Linux — zenity 사용 (설치 필요)
                 result = subprocess.run(
                     ['zenity', '--file-selection', '--directory'],
-                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
+                    capture_output=True, **_TEXT_SUBPROCESS, timeout=60
                 )
                 if result.returncode == 0:
                     self._send_json(200, {'ok': True, 'path': result.stdout.strip()})
@@ -467,7 +470,7 @@ class Handler(SimpleHTTPRequestHandler):
         try:
             result = subprocess.run(
                 ['gemini', '--version'],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=10
             )
             if result.returncode == 0:
                 version = result.stdout.strip() or result.stderr.strip()
@@ -485,7 +488,7 @@ class Handler(SimpleHTTPRequestHandler):
         try:
             result = subprocess.run(
                 ['ollama', '--version'],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=10
             )
             if result.returncode == 0:
                 version = result.stdout.strip() or result.stderr.strip()
@@ -503,7 +506,7 @@ class Handler(SimpleHTTPRequestHandler):
         try:
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--version'],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=10
             )
             if result.returncode == 0:
                 version = result.stdout.strip() or result.stderr.strip()
@@ -618,7 +621,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=60
             )
 
             if result.returncode != 0:
@@ -663,7 +666,7 @@ class Handler(SimpleHTTPRequestHandler):
             # Claude CLI 실행
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt_text],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=120
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -720,7 +723,7 @@ class Handler(SimpleHTTPRequestHandler):
                         timeout=5,
                         check=True,
                         capture_output=True,
-                        text=True, encoding='utf-8', errors='replace'
+                        **_TEXT_SUBPROCESS
                     )
                 except FileNotFoundError:
                     self._send_json(500, {'error': "'open' command not found on PATH"})
@@ -736,7 +739,7 @@ class Handler(SimpleHTTPRequestHandler):
                         timeout=5,
                         check=True,
                         capture_output=True,
-                        text=True, encoding='utf-8', errors='replace'
+                        **_TEXT_SUBPROCESS
                     )
                 except FileNotFoundError:
                     self._send_json(500, {'error': "'xdg-open' command not found on PATH"})
@@ -780,7 +783,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=60
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=60
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -812,7 +815,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=30
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')


### PR DESCRIPTION
## Summary
This PR improves the robustness of subprocess calls throughout the application by explicitly specifying UTF-8 encoding and error handling strategies. This ensures consistent text decoding behavior across different platforms and prevents encoding-related failures when subprocess output contains non-standard characters.

## Key Changes
- Added `encoding='utf-8'` and `errors='replace'` parameters to all `subprocess.run()` calls that use `text=True`
- Applied changes across 14 subprocess invocations in the following areas:
  - AI provider calls (Gemini, Ollama, Claude CLI)
  - Python and package installation handlers
  - Folder browsing dialogs (Windows PowerShell, macOS osascript, Linux zenity)
  - Provider version checks (Gemini, Ollama, Claude)
  - Task prompt and prompt refinement handlers
  - Message classification handler

## Implementation Details
- `encoding='utf-8'`: Explicitly decodes subprocess output as UTF-8 instead of relying on system default encoding
- `errors='replace'`: Replaces any characters that cannot be decoded as UTF-8 with the Unicode replacement character (U+FFFD), preventing crashes on malformed output
- This approach is particularly important for cross-platform compatibility and when dealing with external CLI tools that may produce unexpected character encodings

## Additional Documentation Update
Updated CLAUDE.md to clarify that GitHub issues and PRs should always be accessed through the Agent tool (`mcp__github__`) rather than direct tool invocation.

https://claude.ai/code/session_01H9VKmCV12MvF643RXgaGZ3