### PR TITLE
Improve JSON extraction and prevent stdin issues in Claude CLI calls

### DIFF
--- a/apps/server.py
+++ b/apps/server.py
@@ -204,7 +204,7 @@ def extract_json(text):
         result = _list_from(json.loads(m.group(1)))
         if result is not None:
             return result
-    raise ValueError('JSON 배열을 찾을 수 없습니다.')
+    raise ValueError(f'JSON 배열을 찾을 수 없습니다. AI 응답 내용: {text[:300]!r}')
 
 
 def find_idea(data, idea_id):

--- a/apps/server.py
+++ b/apps/server.py
@@ -158,7 +158,7 @@ def call_ai(prompt, timeout=120):
     else:  # claude_cli (default)
         result = subprocess.run(
             [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-            capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout
+            capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=timeout
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -683,7 +683,7 @@ class Handler(SimpleHTTPRequestHandler):
             # Claude CLI 실행
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt_text],
-                capture_output=True, **_TEXT_SUBPROCESS, timeout=120
+                capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=120
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -800,7 +800,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, **_TEXT_SUBPROCESS, timeout=60
+                capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=60
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
@@ -832,7 +832,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, **_TEXT_SUBPROCESS, timeout=30
+                capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=30
             )
             if result.returncode != 0:
                 raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')

--- a/apps/server.py
+++ b/apps/server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 import json
 import os
 import platform
@@ -183,9 +184,14 @@ def extract_json(text):
         if isinstance(parsed, list):
             return parsed
         if isinstance(parsed, dict):
-            for v in parsed.values():
-                if isinstance(v, list):
-                    return v
+            list_fields = [(k, v) for k, v in parsed.items() if isinstance(v, list)]
+            if len(list_fields) == 1:
+                return list_fields[0][1]
+            if len(list_fields) > 1:
+                keys = ', '.join(repr(k) for k, _ in list_fields)
+                raise ValueError(
+                    f'여러 개의 리스트 필드가 있어 어떤 값을 사용해야 할지 결정할 수 없습니다: {keys}'
+                )
         return None
 
     # ```json ... ``` 블록 우선 시도 (배열 또는 객체)
@@ -204,7 +210,8 @@ def extract_json(text):
         result = _list_from(json.loads(m.group(1)))
         if result is not None:
             return result
-    raise ValueError(f'JSON 배열을 찾을 수 없습니다. AI 응답 내용: {text[:300]!r}')
+    logging.warning('extract_json 실패. AI 응답 내용: %r', text[:300])
+    raise ValueError('JSON 배열을 찾을 수 없습니다.')
 
 
 def find_idea(data, idea_id):
@@ -638,7 +645,7 @@ class Handler(SimpleHTTPRequestHandler):
 
             result = subprocess.run(
                 [str(CLAUDE_BIN), '--print', '--output-format', 'text', prompt],
-                capture_output=True, **_TEXT_SUBPROCESS, timeout=60
+                capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=60
             )
 
             if result.returncode != 0:

--- a/apps/server.py
+++ b/apps/server.py
@@ -179,14 +179,31 @@ def _ensure_packages():
 
 def extract_json(text):
     """CLI 응답에서 JSON 배열 추출. 코드블록 안팎 모두 처리."""
-    # ```json ... ``` 블록 우선 시도
-    m = re.search(r'```(?:json)?\s*(\[.*?\])\s*```', text, re.DOTALL)
+    def _list_from(parsed):
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, dict):
+            for v in parsed.values():
+                if isinstance(v, list):
+                    return v
+        return None
+
+    # ```json ... ``` 블록 우선 시도 (배열 또는 객체)
+    m = re.search(r'```(?:json)?\s*(\[.*?\]|\{.*?\})\s*```', text, re.DOTALL)
     if m:
-        return json.loads(m.group(1))
+        result = _list_from(json.loads(m.group(1)))
+        if result is not None:
+            return result
     # 첫 번째 [ ... ] 추출
     m = re.search(r'(\[.*\])', text, re.DOTALL)
     if m:
         return json.loads(m.group(1))
+    # 첫 번째 { ... } 추출 후 내부 배열 탐색
+    m = re.search(r'(\{.*\})', text, re.DOTALL)
+    if m:
+        result = _list_from(json.loads(m.group(1)))
+        if result is not None:
+            return result
     raise ValueError('JSON 배열을 찾을 수 없습니다.')
 
 

--- a/apps/server.py
+++ b/apps/server.py
@@ -187,30 +187,33 @@ def extract_json(text):
             list_fields = [(k, v) for k, v in parsed.items() if isinstance(v, list)]
             if len(list_fields) == 1:
                 return list_fields[0][1]
-            if len(list_fields) > 1:
-                keys = ', '.join(repr(k) for k, _ in list_fields)
-                raise ValueError(
-                    f'여러 개의 리스트 필드가 있어 어떤 값을 사용해야 할지 결정할 수 없습니다: {keys}'
-                )
         return None
 
-    # ```json ... ``` 블록 우선 시도 (배열 또는 객체)
-    m = re.search(r'```(?:json)?\s*(\[.*?\]|\{.*?\})\s*```', text, re.DOTALL)
+    decoder = json.JSONDecoder()
+
+    # 1. ```json ... ``` 블록 우선 시도 (raw_decode로 중첩 객체 처리)
+    m = re.search(r'```(?:json)?\s*(.*?)\s*```', text, re.DOTALL)
     if m:
-        result = _list_from(json.loads(m.group(1)))
-        if result is not None:
-            return result
-    # 첫 번째 [ ... ] 추출
-    m = re.search(r'(\[.*\])', text, re.DOTALL)
-    if m:
-        return json.loads(m.group(1))
-    # 첫 번째 { ... } 추출 후 내부 배열 탐색
-    m = re.search(r'(\{.*\})', text, re.DOTALL)
-    if m:
-        result = _list_from(json.loads(m.group(1)))
-        if result is not None:
-            return result
-    logging.warning('extract_json 실패. AI 응답 내용: %r', text[:300])
+        try:
+            obj, _ = decoder.raw_decode(m.group(1).strip())
+            result = _list_from(obj)
+            if result is not None:
+                return result
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # 2. 텍스트에서 첫 번째 유효한 [ ... ] 또는 { ... } 탐색
+    for i, c in enumerate(text):
+        if c in ('[', '{'):
+            try:
+                obj, _ = decoder.raw_decode(text, i)
+                result = _list_from(obj)
+                if result is not None:
+                    return result
+            except json.JSONDecodeError:
+                pass
+
+    logging.debug('extract_json 실패. AI 응답 길이: %d', len(text))
     raise ValueError('JSON 배열을 찾을 수 없습니다.')
 
 


### PR DESCRIPTION
## 변경 내용

### 1. `extract_json()` 개선 (`apps/server.py`)

AI CLI 응답에서 JSON 배열을 추출하는 로직을 전면 재작성했습니다.

**기존 문제:**
- `{.*?}` 비탐욕 정규식: 중첩 JSON 객체에서 첫 번째 `}`에서 캡처가 끊김
- `{.*}` 탐욕 정규식: 응답에 `{}` 블록이 여러 개일 때 전체를 캡처해 invalid JSON 생성
- `_list_from()`의 다중 리스트 필드 ValueError: 폴백 체인 전체를 차단

**변경 후:**
- 코드블록 내 JSON: `raw_decode()`로 첫 번째 유효한 JSON 파싱 → 중첩 객체 정상 처리
- 폴백 탐색: 텍스트의 `[`, `{` 위치마다 `raw_decode()` 시도 → over-capture 없음
- `_list_from()`: 다중 리스트 필드 시 `None` 반환으로 폴백 체인 유지

### 2. 로깅 개선

- AI 응답 원문을 로그에 기록하지 않음 (민감 정보 보호)
- 파싱 실패 시 응답 길이만 `debug` 레벨로 기록
- 클라이언트에는 제네릭 에러 메시지(`"JSON 배열을 찾을 수 없습니다."`)만 반환

### 3. `stdin=subprocess.DEVNULL` 추가

Claude CLI를 호출하는 모든 `subprocess.run()` 호출에 `stdin=subprocess.DEVNULL` 추가:
- `call_ai()` (공통 AI 호출 함수)
- `_handle_task_prompt()` (Task 프롬프트 생성)
- `_handle_task_execute()` (Task 실행)
- `_check_claude_version()` (버전 확인)
- 기타 내부 호출 포함 총 5곳

stdin 상속으로 인한 블로킹 현상 방지.