### PR TITLE
debug: include full AI response in extract_json() error message

### DIFF
--- a/apps/server.py
+++ b/apps/server.py
@@ -213,8 +213,7 @@ def extract_json(text):
             except json.JSONDecodeError:
                 pass
 
-    logging.debug('extract_json 실패. AI 응답 길이: %d', len(text))
-    raise ValueError('JSON 배열을 찾을 수 없습니다.')
+    raise ValueError(f'JSON 배열을 찾을 수 없습니다.\nAI 응답:\n{text}')
 
 
 def find_idea(data, idea_id):


### PR DESCRIPTION
Temporary debug change: expose raw AI response in ValueError so the client-facing error shows the actual AI output for diagnosis.

https://claude.ai/code/session_01EwLUvVAMFoaiyyRRVt2WUL