### PR TITLE
fix: switch to ThreadingHTTPServer so heartbeats work during AI calls

### DIFF
--- a/apps/server.py
+++ b/apps/server.py
@@ -11,7 +11,7 @@ import sys
 import threading
 import time
 import webbrowser
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 
 PORT = 5500
@@ -55,7 +55,6 @@ def _find_claude_bin() -> Path:
 CLAUDE_BIN = _find_claude_bin()
 _server_instance = None
 _last_heartbeat = None
-_ai_in_progress = False
 HEARTBEAT_TIMEOUT = 8   # 초: 마지막 heartbeat 후 이 시간이 지나면 종료 확인 시작 (프론트 간격 3s × 2 + 여유 2s)
 STARTUP_GRACE = 30      # 초: 서버 시작 직후 watchdog 대기 시간
 
@@ -614,21 +613,16 @@ class Handler(SimpleHTTPRequestHandler):
             )
             prompt = "\n\n".join(parts)
 
-            global _ai_in_progress
-            _ai_in_progress = True
-            try:
-                response_text = call_ai(
-                    prompt, timeout=120,
-                    system_prompt=(
-                        '당신은 소프트웨어 개발 Task 목록 생성 도구입니다. '
-                        '반드시 [{"name": "작업명", "importance": 숫자}] 형식의 JSON 배열만 출력하세요. '
-                        'importance는 1, 2, 3 중 하나의 정수입니다. '
-                        'id, title, category, description, features, tags 등 다른 필드는 절대 사용하지 마세요. '
-                        '질문 금지. 설명 금지. JSON 배열 외 어떤 텍스트도 출력하지 마세요.'
-                    )
+            response_text = call_ai(
+                prompt, timeout=120,
+                system_prompt=(
+                    '당신은 소프트웨어 개발 Task 목록 생성 도구입니다. '
+                    '반드시 [{"name": "작업명", "importance": 숫자}] 형식의 JSON 배열만 출력하세요. '
+                    'importance는 1, 2, 3 중 하나의 정수입니다. '
+                    'id, title, category, description, features, tags 등 다른 필드는 절대 사용하지 마세요. '
+                    '질문 금지. 설명 금지. JSON 배열 외 어떤 텍스트도 출력하지 마세요.'
                 )
-            finally:
-                _ai_in_progress = False
+            )
             log_path = BASE_DIR / 'ai_debug.log'
             with open(log_path, 'a', encoding='utf-8') as lf:
                 import datetime
@@ -899,9 +893,6 @@ def _watchdog():
         if _last_heartbeat is None:
             print('[watchdog] heartbeat 아직 미수신')
             continue
-        if _ai_in_progress:
-            print('[watchdog] AI 처리 중 → 대기')
-            continue
         elapsed = time.time() - _last_heartbeat
         print(f'[watchdog] 마지막 heartbeat {elapsed:.1f}s 전')
         if elapsed <= HEARTBEAT_TIMEOUT:
@@ -1034,7 +1025,7 @@ if __name__ == '__main__':
     os.chdir(BASE_DIR)
     my_tty = _get_my_tty()
     threading.Thread(target=_ensure_packages, daemon=True).start()
-    _server_instance = HTTPServer(('', PORT), Handler)
+    _server_instance = ThreadingHTTPServer(('', PORT), Handler)
     url = f'http://localhost:{PORT}/main.html'
     print(f'Millestone server running at {url}')
     webbrowser.open(url)


### PR DESCRIPTION
Single-threaded HTTPServer blocked all requests (including heartbeats) during call_ai() which runs up to 120s. ThreadingHTTPServer handles each request in its own thread, so watchdog receives heartbeats normally even while AI is processing.

Also removes the now-unnecessary _ai_in_progress flag and related code.

https://claude.ai/code/session_01EwLUvVAMFoaiyyRRVt2WUL