### PR TITLE
Refactor CLI context handling and add hierarchical system prompts

### DIFF
--- a/apps/server.py
+++ b/apps/server.py
@@ -202,7 +202,7 @@ def call_ai(prompt, timeout=120, system_prompt=None):
             _write_cli_context('gemini_cli', system_prompt, tmp_dir)
             result = subprocess.run(
                 ['gemini', '-p', prompt],
-                capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout, cwd=tmp_dir
+                capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=timeout, cwd=tmp_dir
             )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Gemini CLI 오류')
@@ -340,17 +340,6 @@ def _call_ai_with_retry(prompt, system_prompt=None, timeout=120,
     raise ValueError("형식 오류 — 재시도 후에도 실패\n\n" + "\n\n".join(log))
 
 
-def find_idea(data, idea_id):
-    """data 구조에서 idea_id에 해당하는 idea dict 반환."""
-    for ws in data.get('workspaces', []):
-        for proj in ws.get('projects', []):
-            for ms in proj.get('milestones', []):
-                for idea in ms.get('ideas', []):
-                    if idea.get('id') == idea_id:
-                        return idea
-    return None
-
-
 def find_idea_context(data, idea_id):
     """data 구조에서 idea_id에 해당하는 (workspace, project, milestone, idea) 반환."""
     for ws in data.get('workspaces', []):
@@ -360,6 +349,12 @@ def find_idea_context(data, idea_id):
                     if idea.get('id') == idea_id:
                         return ws, proj, ms, idea
     return None, None, None, None
+
+
+def find_idea(data, idea_id):
+    """data 구조에서 idea_id에 해당하는 idea dict 반환."""
+    _, _, _, idea = find_idea_context(data, idea_id)
+    return idea
 
 
 def find_task(data, task_id):

--- a/apps/server.py
+++ b/apps/server.py
@@ -67,6 +67,21 @@ def build_system_prompt(*parts):
     return " ".join(p.strip() for p in parts if p and p.strip())
 
 
+_CLI_CONTEXT_FILES = {
+    'claude_cli': BASE_DIR / 'CLAUDE.md',
+    'gemini_cli': BASE_DIR / 'GEMINI.md',
+}
+
+
+def _write_cli_context(provider: str, system_prompt: str | None):
+    """CLI 호출 전 컨텍스트 파일을 생성한다. system_prompt가 없으면 아무것도 하지 않는다."""
+    if not system_prompt:
+        return
+    path = _CLI_CONTEXT_FILES.get(provider)
+    if path:
+        path.write_text(system_prompt, encoding='utf-8')
+
+
 def _find_claude_bin() -> Path:
     """OS에 무관하게 claude CLI 실행 파일 경로를 탐색한다."""
     # 1순위: PATH 전체 탐색 (가장 범용적)
@@ -183,10 +198,10 @@ def call_ai(prompt, timeout=120, system_prompt=None):
         return resp.text.strip()
 
     elif provider == 'gemini_cli':
-        effective = f"[System]\n{system_prompt}\n\n{prompt}" if system_prompt else prompt
+        _write_cli_context('gemini_cli', system_prompt)
         result = subprocess.run(
-            ['gemini', '-p', effective],
-            capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout
+            ['gemini', '-p', prompt],
+            capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout, cwd=BASE_DIR
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Gemini CLI 오류')
@@ -205,13 +220,13 @@ def call_ai(prompt, timeout=120, system_prompt=None):
         return result.stdout.strip()
 
     else:  # claude_cli (default)
+        _write_cli_context('claude_cli', system_prompt)
         cmd = [str(CLAUDE_BIN), '--print', '--output-format', 'text']
-        if system_prompt:
-            cmd += ['--system-prompt', system_prompt]
         cmd.append(prompt)
         result = subprocess.run(
             cmd,
-            capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=timeout
+            capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=timeout,
+            cwd=BASE_DIR
         )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')

--- a/apps/server.py
+++ b/apps/server.py
@@ -742,12 +742,12 @@ class Handler(SimpleHTTPRequestHandler):
             )
             prompt = "\n\n".join(parts)
 
-            user_sp = " ".join(filter(None, [
+            user_sp = build_system_prompt(
                 (ws or {}).get('systemPrompt', ''),
                 (proj or {}).get('systemPrompt', ''),
                 (ms or {}).get('systemPrompt', ''),
                 idea.get('systemPrompt', ''),
-            ]))
+            )
             sp = build_system_prompt(_SP_TASK_ROLE, _SP_NO_QUESTION, _SP_TASK_FORMAT, user_sp)
             response_text = _call_ai_with_retry(
                 prompt, system_prompt=sp, timeout=120,

--- a/apps/server.py
+++ b/apps/server.py
@@ -349,6 +349,17 @@ def find_idea(data, idea_id):
     return None
 
 
+def find_idea_context(data, idea_id):
+    """data 구조에서 idea_id에 해당하는 (workspace, project, milestone, idea) 반환."""
+    for ws in data.get('workspaces', []):
+        for proj in ws.get('projects', []):
+            for ms in proj.get('milestones', []):
+                for idea in ms.get('ideas', []):
+                    if idea.get('id') == idea_id:
+                        return ws, proj, ms, idea
+    return None, None, None, None
+
+
 def find_task(data, task_id):
     """data 구조에서 task_id에 해당하는 (idea, task) 반환."""
     for ws in data.get('workspaces', []):
@@ -703,7 +714,7 @@ class Handler(SimpleHTTPRequestHandler):
     def _handle_run_idea(self, idea_id):
         try:
             data = read_data()
-            idea = find_idea(data, idea_id)
+            ws, proj, ms, idea = find_idea_context(data, idea_id)
             if idea is None:
                 self._send_json(404, {'error': f'idea {idea_id} not found'})
                 return
@@ -734,7 +745,13 @@ class Handler(SimpleHTTPRequestHandler):
             )
             prompt = "\n\n".join(parts)
 
-            sp = build_system_prompt(_SP_TASK_ROLE, _SP_NO_QUESTION, _SP_TASK_FORMAT)
+            user_sp = " ".join(filter(None, [
+                (ws or {}).get('systemPrompt', ''),
+                (proj or {}).get('systemPrompt', ''),
+                (ms or {}).get('systemPrompt', ''),
+                idea.get('systemPrompt', ''),
+            ]))
+            sp = build_system_prompt(_SP_TASK_ROLE, _SP_NO_QUESTION, _SP_TASK_FORMAT, user_sp)
             response_text = _call_ai_with_retry(
                 prompt, system_prompt=sp, timeout=120,
                 validate=_validate_task_json, max_retries=2

--- a/apps/server.py
+++ b/apps/server.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import webbrowser
@@ -67,19 +68,18 @@ def build_system_prompt(*parts):
     return " ".join(p.strip() for p in parts if p and p.strip())
 
 
-_CLI_CONTEXT_FILES = {
-    'claude_cli': BASE_DIR / 'CLAUDE.md',
-    'gemini_cli': BASE_DIR / 'GEMINI.md',
+_CLI_CONTEXT_FILENAMES = {
+    'claude_cli': 'CLAUDE.md',
+    'gemini_cli': 'GEMINI.md',
 }
 
 
-def _write_cli_context(provider: str, system_prompt: str | None):
-    """CLI 호출 전 컨텍스트 파일을 생성한다. system_prompt가 없으면 아무것도 하지 않는다."""
-    if not system_prompt:
+def _write_cli_context(provider: str, system_prompt: str | None, directory: str):
+    """요청별 격리 디렉토리에 CLI 컨텍스트 파일을 생성한다."""
+    filename = _CLI_CONTEXT_FILENAMES.get(provider)
+    if not filename or not system_prompt:
         return
-    path = _CLI_CONTEXT_FILES.get(provider)
-    if path:
-        path.write_text(system_prompt, encoding='utf-8')
+    (Path(directory) / filename).write_text(system_prompt, encoding='utf-8')
 
 
 def _find_claude_bin() -> Path:
@@ -198,11 +198,12 @@ def call_ai(prompt, timeout=120, system_prompt=None):
         return resp.text.strip()
 
     elif provider == 'gemini_cli':
-        _write_cli_context('gemini_cli', system_prompt)
-        result = subprocess.run(
-            ['gemini', '-p', prompt],
-            capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout, cwd=BASE_DIR
-        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _write_cli_context('gemini_cli', system_prompt, tmp_dir)
+            result = subprocess.run(
+                ['gemini', '-p', prompt],
+                capture_output=True, **_TEXT_SUBPROCESS, timeout=timeout, cwd=tmp_dir
+            )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Gemini CLI 오류')
         return result.stdout.strip()
@@ -220,14 +221,15 @@ def call_ai(prompt, timeout=120, system_prompt=None):
         return result.stdout.strip()
 
     else:  # claude_cli (default)
-        _write_cli_context('claude_cli', system_prompt)
-        cmd = [str(CLAUDE_BIN), '--print', '--output-format', 'text']
-        cmd.append(prompt)
-        result = subprocess.run(
-            cmd,
-            capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=timeout,
-            cwd=BASE_DIR
-        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _write_cli_context('claude_cli', system_prompt, tmp_dir)
+            cmd = [str(CLAUDE_BIN), '--print', '--output-format', 'text']
+            cmd.append(prompt)
+            result = subprocess.run(
+                cmd,
+                capture_output=True, stdin=subprocess.DEVNULL, **_TEXT_SUBPROCESS, timeout=timeout,
+                cwd=tmp_dir
+            )
         if result.returncode != 0:
             raise RuntimeError(result.stderr.strip() or 'Claude CLI 오류')
         return result.stdout.strip()


### PR DESCRIPTION
## 주요 변경 내용

### CLI 컨텍스트 파일 방식으로 전환
- `_write_cli_context()` 함수 추가: CLI 호출 전 시스템 프롬프트를 컨텍스트 파일(`CLAUDE.md` / `GEMINI.md`)에 기록
- Gemini CLI: `-p` 플래그에 `[System]` 텍스트를 직접 삽입하던 방식 → 컨텍스트 파일 방식으로 변경
- Claude CLI: `--system-prompt` 커맨드라인 인자 제거 → 컨텍스트 파일 방식으로 변경

### 요청별 TemporaryDirectory 격리
- CLI 호출마다 `tempfile.TemporaryDirectory()`를 생성하고 해당 디렉토리에 컨텍스트 파일을 기록
- `cwd=tmp_dir`로 subprocess 실행 → CLI가 해당 임시 디렉토리의 컨텍스트 파일을 자동으로 읽음
- `with` 블록 종료 시 임시 디렉토리 자동 삭제 (파일 잔류 없음)
- 동시 요청 간 프롬프트 혼용(race condition) 방지
- `BASE_DIR` 외부 경로 사용으로 HTTP를 통한 시스템 프롬프트 노출 차단

### 계층별 systemPrompt 상속 (버그 수정)
- `find_idea_context()` 함수 추가: `workspace → project → milestone → idea` 전체 체인 반환
- `_handle_run_idea()`에서 4개 레벨의 `systemPrompt`를 합산하여 AI에 전달
- 기존에는 사용자가 입력한 `systemPrompt`가 Task 생성 시 무시되던 문제 수정