### PR TITLE
Add loading popup with cancellation support for AI task generation

### DIFF
--- a/apps/main.html
+++ b/apps/main.html
@@ -1307,6 +1307,63 @@
     }
     #run-confirm-modal.open { display: flex; }
 
+    /* ── Loading Popup ── */
+    #loading-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      z-index: 300;
+      align-items: center;
+      justify-content: center;
+    }
+    #loading-overlay.open { display: flex; }
+    #loading-popup {
+      background: #fff;
+      border-radius: 14px;
+      padding: 28px 32px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+      min-width: 240px;
+    }
+    body.dark #loading-popup { background: #1e1e1e; }
+    .loading-spinner {
+      width: 36px;
+      height: 36px;
+      border: 3px solid #e0e0e0;
+      border-top-color: #555;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    body.dark .loading-spinner { border-color: #444; border-top-color: #aaa; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    #loading-message {
+      margin: 0;
+      font-size: calc(14px * var(--fs, 1));
+      color: inherit;
+    }
+    .loading-buttons {
+      display: flex;
+      gap: 10px;
+    }
+    .loading-buttons button {
+      padding: 7px 18px;
+      border-radius: 8px;
+      border: 1px solid #d0d0d0;
+      background: none;
+      font-size: calc(13px * var(--fs, 1));
+      color: inherit;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .loading-buttons button:hover { background: rgba(0,0,0,0.06); }
+    body.dark .loading-buttons button { border-color: #555; }
+    body.dark .loading-buttons button:hover { background: rgba(255,255,255,0.08); }
+    #loading-popup.popup-hidden { display: none; }
+
     /* ── Toast ── */
     #toast {
       position: fixed;
@@ -1699,6 +1756,17 @@
       <div class="modal-actions">
         <button class="btn-modal" id="btn-run-confirm-cancel">아니오</button>
         <button class="btn-modal btn-confirm" id="btn-run-confirm-ok">예, 실행</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="loading-overlay">
+    <div id="loading-popup">
+      <div class="loading-spinner"></div>
+      <p id="loading-message">AI가 응답 중입니다...</p>
+      <div class="loading-buttons">
+        <button id="loading-cancel-btn">취소</button>
+        <button id="loading-wait-btn">기다리기</button>
       </div>
     </div>
   </div>
@@ -2234,8 +2302,9 @@
         runBtn.disabled = true;
         const orig = runBtn.innerHTML;
         runBtn.innerHTML = '...';
+        showLoadingPopup();
         try {
-          const res = await fetch(`/api/ideas/${idea.id}/run`, { method: 'POST' });
+          const res = await fetch(`/api/ideas/${idea.id}/run`, { method: 'POST', signal: currentAbortController.signal });
           const updated = await res.json();
           if (updated.error) throw new Error(updated.error);
           idea.tasks = (updated.tasks || []).map(td => {
@@ -2247,8 +2316,9 @@
           renderIdeaDetail(ws, proj, ms, idea);
           renderTree();
         } catch (err) {
-          alert('Task 생성 실패: ' + err.message);
+          if (err.name !== 'AbortError') alert('Task 생성 실패: ' + err.message);
         } finally {
+          hideLoadingPopup();
           runBtn.disabled = false;
           runBtn.innerHTML = orig;
         }
@@ -2553,8 +2623,9 @@
           btn.disabled = true;
           const origHTML = btn.innerHTML;
           btn.innerHTML = '<span style="font-size:calc(11px * var(--fs, 1));padding:0 2px">...</span>';
+          showLoadingPopup();
           try {
-            const res = await fetch(`/api/ideas/${idea.id}/run`, { method: 'POST' });
+            const res = await fetch(`/api/ideas/${idea.id}/run`, { method: 'POST', signal: currentAbortController.signal });
             const updated = await res.json();
             if (updated.error) throw new Error(updated.error);
             idea.tasks = (updated.tasks || []).map(td => {
@@ -2565,8 +2636,9 @@
             renderIdeas(ws, proj, ms);
             renderTree();
           } catch (err) {
-            alert('Task 생성 실패: ' + err.message);
+            if (err.name !== 'AbortError') alert('Task 생성 실패: ' + err.message);
           } finally {
+            hideLoadingPopup();
             btn.disabled = false;
             btn.innerHTML = origHTML;
           }
@@ -3592,6 +3664,30 @@
     function saveTheme(theme) {
       localStorage.setItem(STORAGE_KEY, theme);
     }
+
+    // ── Loading Popup ──
+    let currentAbortController = null;
+
+    function showLoadingPopup() {
+      currentAbortController = new AbortController();
+      document.getElementById('loading-popup').classList.remove('popup-hidden');
+      document.getElementById('loading-overlay').classList.add('open');
+    }
+
+    function hideLoadingPopup() {
+      document.getElementById('loading-overlay').classList.remove('open');
+      document.getElementById('loading-popup').classList.remove('popup-hidden');
+      currentAbortController = null;
+    }
+
+    document.getElementById('loading-cancel-btn').addEventListener('click', () => {
+      currentAbortController?.abort();
+      hideLoadingPopup();
+    });
+
+    document.getElementById('loading-wait-btn').addEventListener('click', () => {
+      document.getElementById('loading-popup').classList.add('popup-hidden');
+    });
 
     // 페이지 로드 시 저장된 테마 및 폰트 스케일 적용
     applyTheme(loadTheme());

--- a/apps/main.html
+++ b/apps/main.html
@@ -2297,8 +2297,9 @@
         if (idea.tasks.length > 0) {
           const confirmed = await showRunConfirm();
           if (!confirmed) return;
-          idea.tasks = [];
         }
+        const previousTasks = idea.tasks.slice();
+        idea.tasks = [];
         runBtn.disabled = true;
         const orig = runBtn.innerHTML;
         runBtn.innerHTML = '...';
@@ -2316,6 +2317,7 @@
           renderIdeaDetail(ws, proj, ms, idea);
           renderTree();
         } catch (err) {
+          idea.tasks = previousTasks;
           if (err.name !== 'AbortError') alert('Task 생성 실패: ' + err.message);
         } finally {
           hideLoadingPopup();
@@ -2617,9 +2619,10 @@
           if (idea.tasks.length > 0) {
             const confirmed = await showRunConfirm();
             if (!confirmed) return;
-            idea.tasks = [];
           }
 
+          const previousTasks = idea.tasks.slice();
+          idea.tasks = [];
           btn.disabled = true;
           const origHTML = btn.innerHTML;
           btn.innerHTML = '<span style="font-size:calc(11px * var(--fs, 1));padding:0 2px">...</span>';
@@ -2636,6 +2639,7 @@
             renderIdeas(ws, proj, ms);
             renderTree();
           } catch (err) {
+            idea.tasks = previousTasks;
             if (err.name !== 'AbortError') alert('Task 생성 실패: ' + err.message);
           } finally {
             hideLoadingPopup();

--- a/apps/main.html
+++ b/apps/main.html
@@ -3687,6 +3687,7 @@
 
     document.getElementById('loading-wait-btn').addEventListener('click', () => {
       document.getElementById('loading-popup').classList.add('popup-hidden');
+      document.getElementById('loading-overlay').classList.remove('open');
     });
 
     // 페이지 로드 시 저장된 테마 및 폰트 스케일 적용

--- a/apps/server.py
+++ b/apps/server.py
@@ -68,7 +68,13 @@ _SP_PROMPT_ROLE = (
 _SP_REFINE_ROLE = (
     "당신은 AI 프롬프트 개선 도구입니다. "
     "원본 프롬프트를 수정 지시에 따라 수정한 결과 텍스트만 출력하라. "
-    "맥락 요청·상태 메시지·설명·질문·'대기 중' 같은 출력은 절대 금지."
+    "맥락 요청·상태 메시지·설명·질문·'대기 중' 같은 출력은 절대 금지. "
+    "수정 원칙: "
+    "(1) 기존 구조 유지 — 전체를 다시 쓰지 말고 필요한 부분만 수정한다. "
+    "(2) 의도 보존 — 수정 지시가 명시하지 않은 내용은 원본 그대로 유지한다. "
+    "(3) 파급 효과 추적 — 수정이 완료 기준·예시·제약 조건 등 다른 섹션과 충돌하면 해당 섹션도 함께 수정한다. "
+    "(4) 충돌 해소 — 수정 지시와 기존 내용이 충돌하면 수정 지시를 우선한다. "
+    "금지: 수정 지시에 없는 내용 추가 또는 삭제, 기존 용어를 동의어로 교체, 섹션 순서 변경, 언어(한국어·영어) 혼용."
 )
 _SP_TASK_FORMAT = (
     '반드시 [{"name":"작업명","importance":숫자}] 형식의 JSON 배열만 출력하세요. '
@@ -1004,7 +1010,8 @@ class Handler(SimpleHTTPRequestHandler):
                              "\n".join(f"{i+1}. {h}" for i, h in enumerate(history_to_show)))
             parts.append(
                 f"[원본 프롬프트]\n{original}\n\n"
-                f"[수정 지시]\n{instruction}"
+                f"[수정 지시]\n{instruction}\n"
+                f"(수정 지시가 영향을 주는 모든 섹션을 일관되게 반영할 것)"
             )
             prompt = "\n\n".join(parts)
             sp = build_system_prompt(_SP_REFINE_ROLE, _SP_NO_QUESTION, _SP_TEXT_ONLY, user_sp)


### PR DESCRIPTION
- [x] Understand the issue: `idea.tasks = []` clears tasks before fetch; cancellation/failure leaves tasks empty
- [x] Fix detail view: save `previousTasks` before clearing, restore on abort/error
- [x] Fix list view: same fix — save and restore `previousTasks` on abort/error
- [x] Validate changes look correct